### PR TITLE
Support for matrix parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.virtualenv
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+*.prof
+*.aux
+*.hp

--- a/servant-client.cabal
+++ b/servant-client.cabal
@@ -1,5 +1,5 @@
 name:                servant-client
-version:             0.2.1
+version:             0.2.2
 synopsis: automatical derivation of querying functions for servant webservices
 description:
   This library lets you derive automatically Haskell functions that
@@ -47,7 +47,7 @@ library
     , http-types
     , network-uri >= 2.6
     , safe
-    , servant >= 0.2.1
+    , servant >= 0.2.2
     , string-conversions
     , text
     , transformers
@@ -71,7 +71,7 @@ test-suite spec
     , hspec == 2.*
     , http-types
     , network >= 2.6
-    , QuickCheck
+    , QuickCheck >= 2.7
     , servant >= 0.2.1
     , servant-client
     , servant-server >= 0.2.1

--- a/src/Servant/Client.hs
+++ b/src/Servant/Client.hs
@@ -210,7 +210,7 @@ instance (KnownSymbol sym, ToText a, HasClient sublayout)
   -- if mparam = Nothing, we don't add it to the query string
   clientWithRoute Proxy req mparam =
     clientWithRoute (Proxy :: Proxy sublayout) $
-      appendToQueryString pname mparamText req
+      maybe req (flip (appendToQueryString pname) req . Just) mparamText
 
     where pname  = cs pname'
           pname' = symbolVal (Proxy :: Proxy sym)
@@ -251,7 +251,7 @@ instance (KnownSymbol sym, ToText a, HasClient sublayout)
 
   clientWithRoute Proxy req paramlist =
     clientWithRoute (Proxy :: Proxy sublayout) $
-      foldl' (\ value req' -> appendToQueryString pname req' value) req paramlist'
+      foldl' (\ req' -> maybe req' (flip (appendToQueryString pname) req' . Just)) req paramlist'
 
     where pname  = cs pname'
           pname' = symbolVal (Proxy :: Proxy sym)

--- a/src/Servant/Client.hs
+++ b/src/Servant/Client.hs
@@ -292,6 +292,121 @@ instance (KnownSymbol sym, HasClient sublayout)
 
     where paramname = cs $ symbolVal (Proxy :: Proxy sym)
 
+-- | If you use a 'MatrixParam' in one of your endpoints in your API,
+-- the corresponding querying function will automatically take
+-- an additional argument of the type specified by your 'MatrixParam',
+-- enclosed in Maybe.
+--
+-- If you give Nothing, nothing will be added to the query string.
+--
+-- If you give a non-'Nothing' value, this function will take care
+-- of inserting a textual representation of this value in the query string.
+--
+-- You can control how values for your type are turned into
+-- text by specifying a 'ToText' instance for your type.
+--
+-- Example:
+--
+-- > type MyApi = "books" :> MatrixParam "author" Text :> Get [Book]
+-- >
+-- > myApi :: Proxy MyApi
+-- > myApi = Proxy
+-- >
+-- > getBooksBy :: Maybe Text -> BaseUrl -> EitherT String IO [Book]
+-- > getBooksBy = client myApi
+-- > -- then you can just use "getBooksBy" to query that endpoint.
+-- > -- 'getBooksBy Nothing' for all books
+-- > -- 'getBooksBy (Just "Isaac Asimov")' to get all books by Isaac Asimov
+instance (KnownSymbol sym, ToText a, HasClient sublayout)
+      => HasClient (MatrixParam sym a :> sublayout) where
+
+  type Client (MatrixParam sym a :> sublayout) =
+    Maybe a -> Client sublayout
+
+  -- if mparam = Nothing, we don't add it to the query string
+  clientWithRoute Proxy req mparam =
+    clientWithRoute (Proxy :: Proxy sublayout) $
+      maybe req (flip (appendToMatrixParams pname . Just) req) mparamText
+
+    where pname = symbolVal (Proxy :: Proxy sym)
+          mparamText = fmap (cs . toText) mparam
+
+-- | If you use a 'MatrixParams' in one of your endpoints in your API,
+-- the corresponding querying function will automatically take an
+-- additional argument, a list of values of the type specified by your
+-- 'MatrixParams'.
+--
+-- If you give an empty list, nothing will be added to the query string.
+--
+-- Otherwise, this function will take care of inserting a textual
+-- representation of your values in the path segment string, under the
+-- same matrix string parameter name.
+--
+-- You can control how values for your type are turned into text by
+-- specifying a 'ToText' instance for your type.
+--
+-- Example:
+--
+-- > type MyApi = "books" :> MatrixParams "authors" Text :> Get [Book]
+-- >
+-- > myApi :: Proxy MyApi
+-- > myApi = Proxy
+-- >
+-- > getBooksBy :: [Text] -> BaseUrl -> EitherT String IO [Book]
+-- > getBooksBy = client myApi
+-- > -- then you can just use "getBooksBy" to query that endpoint.
+-- > -- 'getBooksBy []' for all books
+-- > -- 'getBooksBy ["Isaac Asimov", "Robert A. Heinlein"]'
+-- > --   to get all books by Asimov and Heinlein
+instance (KnownSymbol sym, ToText a, HasClient sublayout)
+      => HasClient (MatrixParams sym a :> sublayout) where
+
+  type Client (MatrixParams sym a :> sublayout) =
+    [a] -> Client sublayout
+
+  clientWithRoute Proxy req paramlist =
+    clientWithRoute (Proxy :: Proxy sublayout) $
+      foldl' (\ req' value -> maybe req' (flip (appendToMatrixParams pname) req' . Just . cs) value) req paramlist'
+
+    where pname  = cs pname'
+          pname' = symbolVal (Proxy :: Proxy sym)
+          paramlist' = map (Just . toText) paramlist
+
+-- | If you use a 'MatrixFlag' in one of your endpoints in your API,
+-- the corresponding querying function will automatically take an
+-- additional 'Bool' argument.
+--
+-- If you give 'False', nothing will be added to the path segment.
+--
+-- Otherwise, this function will insert a value-less matrix parameter
+-- under the name associated to your 'MatrixFlag'.
+--
+-- Example:
+--
+-- > type MyApi = "books" :> MatrixFlag "published" :> Get [Book]
+-- >
+-- > myApi :: Proxy MyApi
+-- > myApi = Proxy
+-- >
+-- > getBooks :: Bool -> BaseUrl -> EitherT String IO [Book]
+-- > getBooks = client myApi
+-- > -- then you can just use "getBooks" to query that endpoint.
+-- > -- 'getBooksBy False' for all books
+-- > -- 'getBooksBy True' to only get _already published_ books
+instance (KnownSymbol sym, HasClient sublayout)
+      => HasClient (MatrixFlag sym :> sublayout) where
+
+  type Client (MatrixFlag sym :> sublayout) =
+    Bool -> Client sublayout
+
+  clientWithRoute Proxy req flag =
+    clientWithRoute (Proxy :: Proxy sublayout) $
+      if flag
+        then appendToMatrixParams paramname Nothing req
+        else req
+
+    where paramname = cs $ symbolVal (Proxy :: Proxy sym)
+
 -- | Pick a 'Method' and specify where the server you want to query is. You get
 -- back the status code and the response body as a 'ByteString'.
 instance HasClient Raw where

--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -41,6 +41,13 @@ appendToPath :: String -> Req -> Req
 appendToPath p req =
   req { reqPath = reqPath req ++ "/" ++ p }
 
+appendToMatrixParams :: String
+                     -> Maybe String
+                     -> Req
+                     -> Req
+appendToMatrixParams pname pvalue req =
+  req { reqPath = reqPath req ++ ";" ++ pname ++ maybe "" ("=" ++) pvalue }
+
 appendToQueryString :: Text       -- ^ param name
                     -> Maybe Text -- ^ param value
                     -> Req


### PR DESCRIPTION
HasClient instances for matrix parameter types. Hmm, made a completely unrelated change as well, I see. When not providing a query parameter at all, "?param=" is inserted into the query string, but the comment said it's being skipped. It makes no difference for servant-server, Nothing is sent to the haskell function either way, but I just figured it was cleaner to not send it at all. Should have put this in a separate PR...

Oh, and I started getting some trouble compiling the tests, and after some googling, -fcontext-stack=25 solved my problem. I didn't delve deeper into the cause...