### PR TITLE
Add TLS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ ghc:
 
 before_install:
   - git clone https://github.com/haskell-servant/servant.git
+  - git clone https://github.com/haskell-servant/servant-server.git
   - cabal sandbox init
   - cabal sandbox add-source servant/
+  - cabal sandbox add-source servant-server/
 
 notifications:
   irc:

--- a/servant-client.cabal
+++ b/servant-client.cabal
@@ -44,6 +44,7 @@ library
     , either
     , exceptions
     , http-client
+    , http-client-tls
     , http-types
     , network-uri >= 2.6
     , safe

--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -19,6 +19,7 @@ import Data.String.Conversions
 import Data.Text
 import Data.Text.Encoding
 import Network.HTTP.Client
+import Network.HTTP.Client.TLS
 import Network.HTTP.Types
 import Network.URI
 import Servant.Common.BaseUrl
@@ -91,7 +92,7 @@ reqToRequest req (BaseUrl reqScheme reqHost reqPort) =
 
 {-# NOINLINE __manager #-}
 __manager :: MVar Manager
-__manager = unsafePerformIO (newManager defaultManagerSettings >>= newMVar)
+__manager = unsafePerformIO (newManager tlsManagerSettings >>= newMVar)
 
 __withGlobalManager :: (Manager -> IO a) -> IO a
 __withGlobalManager action = modifyMVar __manager $ \ manager -> do

--- a/test/Servant/ClientSpec.hs
+++ b/test/Servant/ClientSpec.hs
@@ -246,3 +246,4 @@ pathGen = listOf $ elements $
   filter (not . (`elem` "?%[]/#")) $
   filter isPrint $
   map chr [0..127]
+ 


### PR DESCRIPTION
When I try to connect to an SSL protected Server, I get

```
*** Exception: TlsNotSupported
```

This is because `defaultManagerSettings` don't support TLS. Using `tlsManagerSettings` from `http-client-tls` fixes this.

I am aware that I could also just replace the `Manager` in `__manager` at runtime, but I think this should be the default.