### PR TITLE
Dont ignore content type

### DIFF
--- a/servant-client.cabal
+++ b/servant-client.cabal
@@ -45,6 +45,7 @@ library
     , exceptions
     , http-client
     , http-client-tls
+    , http-media
     , http-types
     , network-uri >= 2.6
     , safe

--- a/servant-client.cabal
+++ b/servant-client.cabal
@@ -71,6 +71,7 @@ test-suite spec
     , deepseq
     , either
     , hspec == 2.*
+    , http-media
     , http-types
     , network >= 2.6
     , QuickCheck >= 2.7

--- a/src/Servant/Client.hs
+++ b/src/Servant/Client.hs
@@ -22,6 +22,7 @@ import Data.Proxy
 import Data.String.Conversions
 import Data.Text (unpack)
 import GHC.TypeLits
+import Network.HTTP.Media
 import qualified Network.HTTP.Types as H
 import Servant.API
 import Servant.Common.BaseUrl
@@ -443,7 +444,7 @@ instance (ToJSON a, HasClient sublayout)
 
   clientWithRoute Proxy req body =
     clientWithRoute (Proxy :: Proxy sublayout) $
-      setRQBody (encode body) req
+      setRQBody (encode body) ("application" // "json" /: ("charset", "utf-8")) req
 
 -- | Make the querying function append @path@ to the request path.
 instance (KnownSymbol path, HasClient sublayout) => HasClient (path :> sublayout) where

--- a/src/Servant/Client.hs
+++ b/src/Servant/Client.hs
@@ -412,7 +412,7 @@ instance (KnownSymbol sym, HasClient sublayout)
 -- | Pick a 'Method' and specify where the server you want to query is. You get
 -- back the status code and the response body as a 'ByteString'.
 instance HasClient Raw where
-  type Client Raw = H.Method -> BaseUrl -> EitherT String IO (Int, ByteString)
+  type Client Raw = H.Method -> BaseUrl -> EitherT String IO (Int, ByteString, MediaType)
 
   clientWithRoute :: Proxy Raw -> Req -> Client Raw
   clientWithRoute Proxy req httpMethod host =

--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -142,7 +142,9 @@ performRequest reqMethod req isWantedStatus reqHost = do
 performRequestJSON :: FromJSON result =>
   Method -> Req -> Int -> BaseUrl -> EitherT String IO result
 performRequestJSON reqMethod req wantedStatus reqHost = do
-  (_status, respBody, _) <- performRequest reqMethod req (== wantedStatus) reqHost
+  (_status, respBody, contentType) <- performRequest reqMethod req (== wantedStatus) reqHost
+  unless (matches contentType ("application"//"json")) $
+    left $ "requested Content-Type application/json, but got " <> show contentType
   either
     (\ message -> left (displayHttpRequest reqMethod ++ " returned invalid json: " ++ message))
     return

--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -13,7 +13,7 @@ import Data.Aeson
 import Data.Aeson.Parser
 import Data.Aeson.Types
 import Data.Attoparsec.ByteString
-import Data.ByteString.Lazy hiding (pack, filter, map)
+import Data.ByteString.Lazy hiding (pack, filter, map, null)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import Data.String
@@ -93,7 +93,8 @@ reqToRequest req (BaseUrl reqScheme reqHost reqPort) =
         setheaders r = r { requestHeaders = requestHeaders r
                                          ++ Prelude.map toProperHeader (headers req) }
         setAccept r = r { requestHeaders = filter ((/= "Accept") . fst) (requestHeaders r)
-                                        ++ [("Accept", BS.intercalate ", " (map renderAccept $ reqAccept req))] }
+                                        ++ [("Accept", BS.intercalate ", " (map renderAccept $ reqAccept req))
+                                              | not . null . reqAccept $ req] }
         renderAccept :: MediaType -> BS.ByteString
         renderAccept m = BSC.pack (show m)
         toProperHeader (name, val) =

--- a/src/Servant/Common/Req.hs
+++ b/src/Servant/Common/Req.hs
@@ -93,10 +93,8 @@ reqToRequest req (BaseUrl reqScheme reqHost reqPort) =
         setheaders r = r { requestHeaders = requestHeaders r
                                          ++ Prelude.map toProperHeader (headers req) }
         setAccept r = r { requestHeaders = filter ((/= "Accept") . fst) (requestHeaders r)
-                                        ++ [("Accept", BS.intercalate ", " (map renderAccept $ reqAccept req))
+                                        ++ [("Accept", renderHeader $ reqAccept req)
                                               | not . null . reqAccept $ req] }
-        renderAccept :: MediaType -> BS.ByteString
-        renderAccept m = BSC.pack (show m)
         toProperHeader (name, val) =
           (fromString name, encodeUtf8 val)
 

--- a/test/Servant/ClientSpec.hs
+++ b/test/Servant/ClientSpec.hs
@@ -17,6 +17,7 @@ import Data.Foldable (forM_)
 import Data.Proxy
 import Data.Typeable
 import GHC.Generics
+import Network.HTTP.Media
 import Network.HTTP.Types
 import Network.Socket
 import Network.Wai
@@ -101,8 +102,8 @@ getQueryFlag :: Bool -> BaseUrl -> EitherT String IO Bool
 getMatrixParam :: Maybe String -> BaseUrl -> EitherT String IO Person
 getMatrixParams :: [String] -> BaseUrl -> EitherT String IO [Person]
 getMatrixFlag :: Bool -> BaseUrl -> EitherT String IO Bool
-getRawSuccess :: Method -> BaseUrl -> EitherT String IO (Int, ByteString)
-getRawFailure :: Method -> BaseUrl -> EitherT String IO (Int, ByteString)
+getRawSuccess :: Method -> BaseUrl -> EitherT String IO (Int, ByteString, MediaType)
+getRawFailure :: Method -> BaseUrl -> EitherT String IO (Int, ByteString, MediaType)
 getMultiple :: String -> Maybe Int -> Bool -> [(String, [Rational])]
   -> BaseUrl
   -> EitherT String IO (String, Maybe Int, Bool, [(String, [Rational])])
@@ -167,10 +168,10 @@ spec = do
       runEitherT (getMatrixFlag flag host) `shouldReturn` Right flag
 
   it "Servant.API.Raw on success" $ withServer $ \ host -> do
-    runEitherT (getRawSuccess methodGet host) `shouldReturn` Right (200, "rawSuccess")
+    runEitherT (getRawSuccess methodGet host) `shouldReturn` Right (200, "rawSuccess", "application"//"octet-stream")
 
   it "Servant.API.Raw on failure" $ withServer $ \ host -> do
-    runEitherT (getRawFailure methodGet host) `shouldReturn` Right (400, "rawFailure")
+    runEitherT (getRawFailure methodGet host) `shouldReturn` Right (400, "rawFailure", "application"//"octet-stream")
 
   modifyMaxSuccess (const 20) $ do
     it "works for a combination of Capture, QueryParam, QueryFlag and ReqBody" $


### PR DESCRIPTION
Currently servant-client completely ignores content-types. This relies on the server also ignoring content-types, which is less than ideal. Also this is also required to make client changes for https://github.com/haskell-servant/servant-server/pull/13.