### PR TITLE
Use an `IORef` rather than a `MVar`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 ---
 * Support content-type aware combinators and `Accept`/`Content-type` headers
 * Added a lot of tests
+* Support multiple concurrent threads
 
 0.2.2
 -----
 * Add TLS support
-* Add matrix parameter support 
+* Add matrix parameter support


### PR DESCRIPTION
The job of a manager is to synchronize threads, so it is not necessary to block.