### PR TITLE
canonicalize api type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added a lot of tests
 * Support multiple concurrent threads
 * Use `ServantError` to report Errors instead of `String`
+* `Canonicalize` API types before generating client functions for them
 
 0.2.2
 -----


### PR DESCRIPTION
See haskell-servant/servant#23. This runs `Canonicalize` on the API type to flatten all arguments and distribute them to each function. Basically makes sure this holds:

``` haskell
Client (a :<|> b) = Client a :<|> Client b -- this one already holds
Client (a :> (b :<|> c)) = Client (a :> b) :<|> Client (a :> c) -- this one doesn't
```

Other PRs:
- haskell-servant/servant#23
- haskell-servant/servant-server#32
- haskell-servant/servant-jquery#10
- haskell-servant/servant-docs#16

