### PR TITLE
Accept wider range of return codes

### DIFF
--- a/src/Servant/Client.hs
+++ b/src/Servant/Client.hs
@@ -111,7 +111,7 @@ instance HasClient Delete where
   type Client Delete = BaseUrl -> EitherT ServantError IO ()
 
   clientWithRoute Proxy req host =
-    void $ performRequest H.methodDelete req (== 204) host
+    void $ performRequest H.methodDelete req (`elem` [200, 202, 204]) host
 
 -- | If you have a 'Get' endpoint in your API, the client
 -- side querying function that is created when calling 'client'
@@ -120,7 +120,7 @@ instance HasClient Delete where
 instance (MimeUnrender ct result) => HasClient (Get (ct ': cts) result) where
   type Client (Get (ct ': cts) result) = BaseUrl -> EitherT ServantError IO result
   clientWithRoute Proxy req host =
-    performRequestCT (Proxy :: Proxy ct) H.methodGet req [200] host
+    performRequestCT (Proxy :: Proxy ct) H.methodGet req [200, 203] host
 
 -- | If you use a 'Header' in one of your endpoints in your API,
 -- the corresponding querying function will automatically take


### PR DESCRIPTION
DELETE
201 doesn't make sense
I think we can get away with just 204 without 205 and 206

GET
206 should be handled by the lib itself (?) so we only add 203

Closes #20 

It may be tempting to just accept every 2xx but it really doesn't make sense for many things: created code for DELETE for example or more exotic codes where it's even less clear what to do.